### PR TITLE
4 create an event waiter class

### DIFF
--- a/.github/workflows/build.yaml
+++ b/.github/workflows/build.yaml
@@ -16,6 +16,6 @@ jobs:
       - name: Install Dependencies
         run: yarn
       - name: Lint
-        run: npm run lint
+        run: yarn lint
       - name: Test
-        run: npm run test
+        run: yarn test:unit

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 dist/
 node_modules/
+coverage/
 
 .DS_Store

--- a/hak-core/src/bus/EventBus.ts
+++ b/hak-core/src/bus/EventBus.ts
@@ -11,9 +11,16 @@ export interface EventBus {
   addListener<T>(event: string, callback: (payload: T) => void): void;
 
   /**
+   * Removes a listener for events with the specified name.
+   * @param event Name of event to listen for
+   * @param callback Callback to remove
+   */
+  removeListener<T>(event: string, callback: (payload: T) => void): void;
+
+  /**
    * Fires an event with the specified name.
    * @param event Name of event to fire
    * @param payload Contents of event to pass to callback of registered listeners
    */
-   fireEvent<T>(event: string, payload: T): void;
+  fireEvent<T>(event: string, payload: T): void;
 }

--- a/hak-core/src/bus/EventWaiter.ts
+++ b/hak-core/src/bus/EventWaiter.ts
@@ -1,0 +1,62 @@
+import { EventBus } from './EventBus';
+import { WaitForEventOptions } from './WaitForEventOptions';
+
+/**
+ * Provides a utility container for waiting for events
+ */
+export class EventWaiter<T> {
+  private eventBus: EventBus;
+  private listener: (payload: T) => void;
+  private resolved: boolean;
+
+  /**
+   * Creates a new instance associated with the EventBus provided
+   * @param eventBus EventBus instance to listen for events on
+   */
+  constructor(eventBus: EventBus) {
+    this.eventBus = eventBus;
+  }
+
+  /**
+   * Waits for an event to be fired and optionally executes a functions
+   * prior to resolving the promise
+   * @param options Options
+   * @returns Promise resolved once the event is fired and optional filter is matched
+   * and rejected when the timeout is exceeded
+   */
+  private waitForEvent(options: WaitForEventOptions<T>) {
+    this.resolved = false;
+    return new Promise((resolve, reject) => {
+      setTimeout(() => {
+        if (!this.resolved) {
+          reject(new Error(`Timeout waiting for event ${options.event}`));
+        }
+      }, options.timeout);
+
+      this.listener = (payload) => {
+        if (!options.filter || options.filter(payload)) {
+          this.resolved = true;
+          this.eventBus.removeListener(options.event, this.listener);
+
+          if (options.after) {
+            options.after();
+          }
+
+          resolve(payload);
+        }
+      };
+
+      this.eventBus.addListener(options.event, this.listener);
+
+      if (options.before) {
+        options.before();
+      }
+    });
+  }
+
+  public static async waitForEvent<T>(eventBus: EventBus, options: WaitForEventOptions<T>) {
+    const eventWaiter = new EventWaiter(eventBus);
+  
+    return eventWaiter.waitForEvent(options);
+  }
+}

--- a/hak-core/src/bus/LocalEventBus.ts
+++ b/hak-core/src/bus/LocalEventBus.ts
@@ -24,6 +24,15 @@ export class LocalEventBus implements EventBus {
   }
 
   /**
+   * Removes a listener for events with the specified name.
+   * @param event Name of event to listen for
+   * @param callback Callback to remove
+   */
+  public removeListener<T>(event: string, callback: (payload: T) => void) {
+    this.eventEmitter.removeListener(event, callback);
+  }
+
+  /**
    * Fires an event with the specified name.
    * @param event Name of event to fire
    * @param payload Contents of event to pass to callback of registered listeners

--- a/hak-core/src/bus/WaitForEventOptions.ts
+++ b/hak-core/src/bus/WaitForEventOptions.ts
@@ -1,0 +1,7 @@
+export interface WaitForEventOptions<T> {
+  event: string;
+  timeout: number;
+  filter?: (payload: T) => boolean;
+  before?: () => void;
+  after?: () => void;
+}

--- a/hak-core/tests/unit/bus/EventWaiter.spec.ts
+++ b/hak-core/tests/unit/bus/EventWaiter.spec.ts
@@ -1,0 +1,44 @@
+import { LocalEventBus } from '../../../src/bus/LocalEventBus';
+import { EventWaiter } from '../../../src/bus/EventWaiter';
+
+describe('EventWaiter', () => {
+  afterAll(() => jest.resetAllMocks());
+
+  const bus = new LocalEventBus();
+  const event = 'foo';
+  const timeout = 1000;
+
+  it('should wait for an event', async () => {
+    const mockCallback = jest.fn();
+    
+    bus.addListener(event, mockCallback);
+    await EventWaiter.waitForEvent(bus, {
+      event,
+      timeout,
+      filter: payload => payload === 'bar',
+      before: () => bus.fireEvent(event, 'bar'),
+      after: () => bus.fireEvent(event, 'baz'),
+    });
+    
+    
+    expect(mockCallback.mock.calls.length).toBe(2);
+    expect(mockCallback.mock.calls[0][0]).toBe('bar');
+    expect(mockCallback.mock.calls[1][0]).toBe('baz');
+  });
+  
+  it('should timeout if event is not fired', async () => {
+    await expect(EventWaiter.waitForEvent(bus, {
+        event,
+        timeout: 10,
+      })).rejects.toThrow(`Timeout waiting for event ${event}`);
+  });
+
+  it('should timeout if filter is not met', async () => {
+    await expect(EventWaiter.waitForEvent(bus, {
+      event,
+      timeout: 10,
+      filter: payload => payload === 'invalid',
+      before: () => bus.fireEvent(event, 'bar'),
+    })).rejects.toThrow(`Timeout waiting for event ${event}`);
+  });
+});

--- a/hak-core/tests/unit/bus/LocalEventBus.spec.ts
+++ b/hak-core/tests/unit/bus/LocalEventBus.spec.ts
@@ -3,13 +3,30 @@ import { LocalEventBus } from '../../../src/bus/LocalEventBus';
 describe('LocalEventBus', () => {
   afterAll(() => jest.resetAllMocks());
 
-  it('should fire and handle events', () => {
-    const bus = new LocalEventBus();
-    const eventName = 'foo';
+  const bus = new LocalEventBus();
+  const eventName = 'foo';
+
+  it('should send event payloads to listeners', () => {
     const mockCallback = jest.fn();
 
     bus.addListener<string>(eventName, mockCallback);
     bus.fireEvent<string>(eventName, 'bar');
+    bus.fireEvent<string>(eventName, 'baz');
+
+    expect(mockCallback.mock.calls.length).toBe(2);
+    expect(mockCallback.mock.calls[0][0]).toBe('bar');
+    expect(mockCallback.mock.calls[1][0]).toBe('baz');
+  });
+
+  it('should ignore events after listener is removed', () => {
+    const mockCallback = jest.fn();
+
+    bus.addListener<string>(eventName, mockCallback);
+    bus.fireEvent<string>(eventName, 'bar');
+
+    bus.removeListener<string>(eventName, mockCallback);
+    bus.fireEvent<string>(eventName, 'baz');
+
     expect(mockCallback.mock.calls.length).toBe(1);
     expect(mockCallback.mock.calls[0][0]).toBe('bar');
   });

--- a/jest.config.js
+++ b/jest.config.js
@@ -6,6 +6,7 @@ module.exports = {
   resetMocks: true,
   coverageDirectory: 'coverage',
   collectCoverageFrom: [
-    './src/**/*'
+    './**/src/**/*',
+    '!./dist/**/*'
   ],
 }

--- a/package.json
+++ b/package.json
@@ -3,7 +3,9 @@
   "private": true,
   "version": "0.0.0",
   "scripts": {
-    "test": "jest --verbose --testPathPattern=\\.spec\\.ts",
+    "test": "jest --verbose --testPathPattern=\\.spec\\.ts --runInBand --coverage",
+    "test:unit": "jest --testPathPattern=unit.*\\.spec\\.ts --coverage",
+    "test:debug": "node --trace-warnings node_modules/.bin/jest",
     "build": "tsc --project tsconfig.json --diagnostics",
     "lint": "eslint **/src/** **/tests/**",
     "prettier": "prettier --write \"**/src/**/*.ts\" \"**/tests/**/*.spec.ts\""


### PR DESCRIPTION
# Summary

Add EventWaiter class

## Impacted Features

New `EventWaiter` class with single static method as follows:

```
waitForEvent<T>(eventBus: EventBus, options: WaitForEventOptions<T>)
```

with `WaitForEventOptions` as follows:

```
  event: string;
  timeout: number;
  filter?: (payload: T) => boolean;
  before?: () => void;
  after?: () => void;
```

## Testing

Unit test waiting for an event to fire.

## Comments

Closes #4